### PR TITLE
Dynamic parameter changes with `rqt_reconfigure`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,6 @@ add_dependencies(demo patchworkpp_generate_messages_cpp)
 
 add_executable(demo_reconf src/demo_reconf.cpp)
 target_link_libraries(demo_reconf ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${OpenCV_LIBRARIES})
-target_compile_options(demo_reconf PRIVATE -Wsign-compare -Wunused-variable)
 add_dependencies(demo_reconf patchworkpp_generate_messages_cpp)
 
 add_executable(video src/video.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ add_dependencies(demo patchworkpp_generate_messages_cpp)
 
 add_executable(demo_reconf src/demo_reconf.cpp)
 target_link_libraries(demo_reconf ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${OpenCV_LIBRARIES})
+target_compile_options(demo_reconf PRIVATE -Wsign-compare -Wunused-variable)
 add_dependencies(demo_reconf patchworkpp_generate_messages_cpp)
 
 add_executable(video src/video.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(catkin REQUIRED COMPONENTS
         laser_geometry
         sensor_msgs
         message_generation
+        dynamic_reconfigure
         jsk_recognition_msgs
 )
 
@@ -48,6 +49,10 @@ if (OPENMP_FOUND)
     set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 endif()
 
+generate_dynamic_reconfigure_options(
+  cfg/patchwork.cfg
+)
+
 catkin_package(
         INCLUDE_DIRS
         LIBRARIES
@@ -68,6 +73,10 @@ add_dependencies(offline_kitti patchworkpp_generate_messages_cpp)
 add_executable(demo src/demo.cpp)
 target_link_libraries(demo ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${OpenCV_LIBRARIES})
 add_dependencies(demo patchworkpp_generate_messages_cpp)
+
+add_executable(demo_reconfigure src/demo_reconfigure.cpp)
+target_link_libraries(demo_reconfigure ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${OpenCV_LIBRARIES})
+add_dependencies(demo_reconfigure patchworkpp_generate_messages_cpp)
 
 add_executable(video src/video.cpp)
 target_link_libraries(video ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${OpenCV_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,16 @@
-option(BUILD_JSK_PKGS "Enable building of required components of jsk_recognition_msgs and jsk_rviz_plugins" ON)
+cmake_minimum_required(VERSION 3.0.2)
+project(patchworkpp)
 
+set(CMAKE_BUILD_TYPE "Release")
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+option(BUILD_JSK_PKGS "Enable building of required components of jsk_recognition_msgs and jsk_rviz_plugins" ON)
 if(BUILD_JSK_PKGS)
     add_subdirectory(include/jsk_recognition_msgs)
 #     add_subdirectory(include/jsk_rviz_plugins) #TODO: allow building of rviz plugins as well
 endif()
-
-cmake_minimum_required(VERSION 3.0.2)
-project(patchworkpp)
-
-add_compile_options(-std=c++17)
-set(CMAKE_BUILD_TYPE "Release")
-
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 find_package(catkin REQUIRED COMPONENTS
         roscpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,9 +74,9 @@ add_executable(demo src/demo.cpp)
 target_link_libraries(demo ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${OpenCV_LIBRARIES})
 add_dependencies(demo patchworkpp_generate_messages_cpp)
 
-add_executable(demo_reconfigure src/demo_reconfigure.cpp)
-target_link_libraries(demo_reconfigure ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${OpenCV_LIBRARIES})
-add_dependencies(demo_reconfigure patchworkpp_generate_messages_cpp)
+add_executable(demo_reconf src/demo_reconf.cpp)
+target_link_libraries(demo_reconf ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${OpenCV_LIBRARIES})
+add_dependencies(demo_reconf patchworkpp_generate_messages_cpp)
 
 add_executable(video src/video.cpp)
 target_link_libraries(video ${catkin_LIBRARIES} ${PCL_LIBRARIES} ${OpenCV_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ $ roslaunch patchworkpp demo.launch
 $ rosbag play kitti_00_sample.bag
 ```
 
+or run the demo that is dynamically reconfigurable with `rqt_reconfigure`
+
+```bash
+# Start reconfigurable Patchwork++
+$ roslaunch patchworkpp demo_reconf.launch
+# Start the bag file
+$ rosbag play kitti_00_sample.bag
+```
+
 ## :pushpin: TODO List
 - [ ] Update additional demo codes processing data with .bin file format
 - [ ] Generalize point type in the source code

--- a/cfg/patchwork.cfg
+++ b/cfg/patchwork.cfg
@@ -8,6 +8,7 @@ gen.add("save_flag", bool_t, 0, "Flag to save the configuration file", True)
 # patchworkpp
 gen.add("sensor_height", double_t, 0, "Height of the sensor from the ground", 1.723, 0.0, 100.0)
 gen.add("mode", str_t, 0, "Mode of operation", "czm")
+gen.add("cloud_topic", str_t, 0, "PointCloud Topic", "/kitti/velo/pointcloud")
 gen.add("verbose", bool_t, 0, "Verbose mode for debugging", False)
 gen.add("visualize", bool_t, 0, "Flag to visualize the ground likelihood estimation", True)
 
@@ -25,7 +26,6 @@ gen.add("uprightness_thr", double_t, 0, "Threshold of uprightness using in Groun
 gen.add("adaptive_seed_selection_margin", double_t, 0, "The points below the adaptive_seed_selection_margin * sensor_height are filtered", -1.2, -10.0, 10.0)
 
 # czm
-gen.add("czm_num_zones", int_t, 0, "Number of zones in czm mode", 4, 0, 10)
 gen.add("czm_num_sectors_each_zone", str_t, 0, "Number of sectors in each zone", "16, 32, 54, 32")
 gen.add("czm_num_rings_each_zone", str_t, 0, "Number of rings in each zone", "2, 4, 4, 4")
 gen.add("czm_elevation_thresholds", str_t, 0, "Threshold of elevation for each ring using in GLE. Those values are updated adaptively.", "0.0, 0.0, 0.0, 0.0")

--- a/cfg/patchwork.cfg
+++ b/cfg/patchwork.cfg
@@ -1,0 +1,44 @@
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+gen = ParameterGenerator()
+
+# save_flag
+gen.add("save_flag", bool_t, 0, "Flag to save the configuration file", True)
+
+# patchworkpp
+gen.add("sensor_height", double_t, 0, "Height of the sensor from the ground", 1.723, 0.0, 100.0)
+gen.add("mode", str_t, 0, "Mode of operation", "czm")
+gen.add("verbose", bool_t, 0, "Verbose mode for debugging", False)
+gen.add("visualize", bool_t, 0, "Flag to visualize the ground likelihood estimation", True)
+
+# Ground Plane Fitting parameters
+gen.add("num_iter", int_t, 0, "Number of iterations for ground plane estimation using PCA", 3, 0, 10)
+gen.add("num_lpr", int_t, 0, "Maximum number of points to be selected as lowest points representative", 20, 0, 100)
+gen.add("num_min_pts", int_t, 0, "Minimum number of points to be estimated as ground plane in each patch", 10, 0, 100)
+gen.add("th_seeds", double_t, 0, "Threshold for lowest point representatives using in initial seeds selection of ground points", 0.3, 0.0, 1.0)
+gen.add("th_dist", double_t, 0, "Threshold for thickness of ground", 0.125, 0.0, 1.0)
+gen.add("th_seeds_v", double_t, 0, "Threshold for lowest point representatives using in initial seeds selection of vertical structural points", 0.25, 0.0, 1.0)
+gen.add("th_dist_v", double_t, 0, "Threshold for thickness of vertical structure", 0.1, 0.0, 1.0)
+gen.add("max_r", double_t, 0, "Maximum range of ground estimation area", 80.0, 0.0, 1000.0)
+gen.add("min_r", double_t, 0, "Minimum range of ground estimation area", 2.7, 0.0, 100.0)
+gen.add("uprightness_thr", double_t, 0, "Threshold of uprightness using in Ground Likelihood Estimation(GLE)", 0.707, 0.0, 1.0)
+gen.add("adaptive_seed_selection_margin", double_t, 0, "The points below the adaptive_seed_selection_margin * sensor_height are filtered", -1.2, -10.0, 10.0)
+
+# czm
+gen.add("czm_num_zones", int_t, 0, "Number of zones in czm mode", 4, 0, 10)
+gen.add("czm_num_sectors_each_zone", str_t, 0, "Number of sectors in each zone", "16, 32, 54, 32")
+gen.add("czm_num_rings_each_zone", str_t, 0, "Number of rings in each zone", "2, 4, 4, 4")
+gen.add("czm_elevation_thresholds", str_t, 0, "Threshold of elevation for each ring using in GLE. Those values are updated adaptively.", "0.0, 0.0, 0.0, 0.0")
+gen.add("czm_flatness_thresholds", str_t, 0, "Threshold of flatness for each ring using in GLE. Those values are updated adaptively.", "0.0, 0.0, 0.0, 0.0")
+
+# enable/disable options
+gen.add("enable_RNR", bool_t, 0, "Flag to enable/disable RNR", True)
+gen.add("enable_RVPF", bool_t, 0, "Flag to enable/disable RVPF", True)
+gen.add("enable_TGR", bool_t, 0, "Flag to enable/disable TGR", True)
+
+# RNR parameters
+gen.add("RNR_ver_angle_thr", double_t, 0, "Noise points vertical angle threshold. Downward rays of LiDAR are more likely to generate severe noise points.", -15.0, -90.0, 90.0)
+gen.add("RNR_intensity_thr", double_t, 0, "Noise points intensity threshold. The reflected points have relatively small intensity than others.", 0.2, 0.0, 1.0)
+
+# Generate the .cfg file
+exit(gen.generate("patchworkpp", "demo", "Patchworkpp"))

--- a/cfg/patchwork.cfg
+++ b/cfg/patchwork.cfg
@@ -12,7 +12,7 @@ gen.add("verbose", bool_t, 0, "Verbose mode for debugging", False)
 gen.add("visualize", bool_t, 0, "Flag to visualize the ground likelihood estimation", True)
 
 # Ground Plane Fitting parameters
-gen.add("num_iter", int_t, 0, "Number of iterations for ground plane estimation using PCA", 3, 0, 10)
+gen.add("num_iter", int_t, 0, "Number of iterations for ground plane estimation using PCA", 3, 1, 10)
 gen.add("num_lpr", int_t, 0, "Maximum number of points to be selected as lowest points representative", 20, 0, 100)
 gen.add("num_min_pts", int_t, 0, "Minimum number of points to be estimated as ground plane in each patch", 10, 0, 100)
 gen.add("th_seeds", double_t, 0, "Threshold for lowest point representatives using in initial seeds selection of ground points", 0.3, 0.0, 1.0)

--- a/include/patchworkpp/params.hpp
+++ b/include/patchworkpp/params.hpp
@@ -1,0 +1,169 @@
+#ifndef PATCHWORKPP_PARAMS
+#define PATCHWORKPP_PARAMS
+
+#include <regex>
+#include <vector>
+#include <stdexcept>
+#include <ros/ros.h>
+#include <dynamic_reconfigure/server.h>
+#include <patchworkpp/PatchworkppConfig.h>
+
+class ParamsNh
+{
+public:
+  ParamsNh() {
+    auto f = boost::bind(&ParamsNh::reconfigure_callback, this, _1, _2);
+    server_.setCallback(f);
+    validate();
+  }
+
+  ParamsNh(const ros::NodeHandle& nh) {
+    nh.param("verbose", verbose_, false);
+    nh.param("sensor_height", sensor_height_, 1.723);
+    nh.param("num_iter", num_iter_, 3);
+    nh.param("num_lpr", num_lpr_, 20);
+    nh.param("num_min_pts", num_min_pts_, 10);
+    nh.param("th_seeds", th_seeds_, 0.4);
+    nh.param("th_dist", th_dist_, 0.3);
+    nh.param("th_seeds_v", th_seeds_v_, 0.4);
+    nh.param("th_dist_v", th_dist_v_, 0.3);
+    nh.param("max_r", max_range_, 80.0);
+    nh.param("min_r", min_range_, 2.7);
+    nh.param("uprightness_thr", uprightness_thr_, 0.5);
+    nh.param("adaptive_seed_selection_margin", adaptive_seed_selection_margin_, -1.1);
+    nh.param("RNR_ver_angle_thr", RNR_ver_angle_thr_, -15.0);
+    nh.param("RNR_intensity_thr", RNR_intensity_thr_, 0.2);
+    nh.param("max_flatness_storage", max_flatness_storage_, 1000);
+    nh.param("max_elevation_storage", max_elevation_storage_, 1000);
+    nh.param("enable_RNR", enable_RNR_, true);
+    nh.param("enable_RVPF", enable_RVPF_, true);
+    nh.param("enable_TGR", enable_TGR_, true);
+
+    // CZM denotes 'Concentric Zone Model'. Please refer to our paper
+    nh.getParam("czm/num_zones", czm.num_zones_);
+    nh.getParam("czm/num_sectors_each_zone", czm.num_sectors_each_zone_);
+    nh.getParam("czm/num_rings_each_zone", czm.num_rings_each_zone_);
+    nh.getParam("czm/elevation_thresholds", czm.elevation_thresholds_);
+    nh.getParam("czm/flatness_thresholds", czm.flatness_thresholds_);
+
+    initialized_ = true;
+    validate();
+  }
+
+  void print_params() const {
+    ROS_INFO("Sensor Height: %f", sensor_height_);
+    ROS_INFO("Num of Iteration: %d", num_iter_);
+    ROS_INFO("Num of LPR: %d", num_lpr_);
+    ROS_INFO("Num of min. points: %d", num_min_pts_);
+    ROS_INFO("Seeds Threshold: %f", th_seeds_);
+    ROS_INFO("Distance Threshold: %f", th_dist_);
+    ROS_INFO("Max. range:: %f", max_range_);
+    ROS_INFO("Min. range:: %f", min_range_);
+    ROS_INFO("Normal vector threshold: %f", uprightness_thr_);
+    ROS_INFO("adaptive_seed_selection_margin: %f", adaptive_seed_selection_margin_);
+  }
+
+    bool validate() {
+    return  check(czm.num_zones_ == czm.num_sectors_each_zone_.size(), "num_zones and length of num_sectors_each_zone must match") &&\
+            check(czm.num_zones_ == czm.num_rings_each_zone_.size(), "num_zones and length of num_rings_each_zone must match") &&\
+            check(czm.num_zones_ == czm.elevation_thresholds_.size(), "num_zones and length of elevation_thresholds must match") &&\
+            check(czm.num_zones_ == czm.flatness_thresholds_.size(), "num_zones and length of flatness_thresholds must match");
+  }
+
+private:
+  void reconfigure_callback(const patchworkpp::PatchworkppConfig& config, uint32_t level) {
+    verbose_ = config.verbose;
+    sensor_height_ = config.sensor_height;
+    num_iter_ = config.num_iter;
+    num_lpr_ = config.num_lpr;
+    num_min_pts_ = config.num_min_pts;
+    th_seeds_ = config.th_seeds;
+    th_dist_ = config.th_dist;
+    th_seeds_v_ = config.th_seeds_v;
+    th_dist_v_ = config.th_dist_v;
+    uprightness_thr_ = config.uprightness_thr;
+    adaptive_seed_selection_margin_ = config.adaptive_seed_selection_margin;
+    RNR_ver_angle_thr_ = config.RNR_ver_angle_thr;
+    RNR_intensity_thr_ = config.RNR_intensity_thr;
+    enable_RNR_ = config.enable_RNR;
+    enable_RVPF_ = config.enable_RVPF;
+    enable_TGR_ = config.enable_TGR;
+
+    czm.num_zones_ = config.czm_num_zones;
+    czm.num_sectors_each_zone_ = convert_string_to_vector<int>(config.czm_num_sectors_each_zone);
+    czm.num_rings_each_zone_ = convert_string_to_vector<int>(config.czm_num_rings_each_zone);
+    czm.elevation_thresholds_ = convert_string_to_vector<double>(config.czm_elevation_thresholds);
+    czm.flatness_thresholds_ = convert_string_to_vector<double>(config.czm_flatness_thresholds);
+
+    ROS_INFO("Updated params");
+    initialized_ = true;
+    validate();
+  }
+
+
+  template <typename T>
+  std::vector<T> convert_string_to_vector(const std::string& str, char separator = ',') {
+      std::vector<T> result;
+      std::istringstream iss(str);
+      std::string token;
+      
+      while (std::getline(iss, token, separator)) {
+        token = std::regex_replace(token, std::regex("\\s+"), "");
+        T num;
+        std::stringstream stream(token);
+        stream >> num;
+        if (stream.fail()) {
+            ROS_WARN_STREAM("Can't convert " << token << " to number");
+            return result;
+        }
+      }
+      
+      return result;
+  }
+
+
+  bool check(bool assertion, std::string description) {
+    if (not assertion) {
+        ROS_WARN_STREAM(description);
+        return false;
+    }
+
+    return true;
+  }
+
+  std::string mode_;
+  bool initialized_;
+  bool verbose_;
+  double sensor_height_;
+  int num_iter_;
+  int num_lpr_;
+  int num_min_pts_;
+  double th_seeds_;
+  double th_dist_;
+  double th_seeds_v_;
+  double th_dist_v_;
+  double max_range_;
+  double min_range_;
+  double uprightness_thr_;
+  double adaptive_seed_selection_margin_;
+  double RNR_ver_angle_thr_;
+  double RNR_intensity_thr_;
+  int max_flatness_storage_;
+  int max_elevation_storage_;
+  bool enable_RNR_;
+  bool enable_RVPF_;
+  bool enable_TGR_;
+  
+  struct CZM
+  {
+    int num_zones_;
+    std::vector<int> num_sectors_each_zone_;
+    std::vector<int> num_rings_each_zone_;
+    std::vector<double> elevation_thresholds_;
+    std::vector<double> flatness_thresholds_;
+  } czm;
+
+  dynamic_reconfigure::Server<patchworkpp::PatchworkppConfig> server_;
+};
+
+#endif 

--- a/include/patchworkpp/params.hpp
+++ b/include/patchworkpp/params.hpp
@@ -23,7 +23,9 @@ public:
         nh.param("sensor_height", sensor_height_, 1.723);
         nh.param("num_iter", num_iter_, 3);
         nh.param("num_lpr", num_lpr_, 20);
-        nh.param("num_min_pts", num_min_pts_, 10);
+        int tmp = 0;
+        nh.param("num_min_pts", tmp, 10);
+        num_min_pts_ = tmp;
         nh.param("th_seeds", th_seeds_, 0.4);
         nh.param("th_dist", th_dist_, 0.3);
         nh.param("th_seeds_v", th_seeds_v_, 0.4);
@@ -41,8 +43,12 @@ public:
         nh.param("enable_TGR", enable_TGR_, true);
 
         // CZM denotes 'Concentric Zone Model'. Please refer to our paper
-        nh.getParam("czm/num_sectors_each_zone", czm.num_sectors_each_zone_);
-        nh.getParam("czm/num_rings_each_zone", czm.num_rings_each_zone_);
+        std::vector<int> temp;
+        nh.getParam("czm/num_sectors_each_zone", temp);
+        std::transform(temp.begin(), temp.end(), std::back_inserter(czm.num_sectors_each_zone_), [](int value) { return static_cast<size_t>(value); });
+        temp.clear();
+        nh.getParam("czm/num_rings_each_zone", temp);
+        std::transform(temp.begin(), temp.end(), std::back_inserter(czm.num_rings_each_zone_), [](int value) { return static_cast<size_t>(value); });
         nh.getParam("czm/elevation_thresholds", czm.elevation_thr_);
         nh.getParam("czm/flatness_thresholds", czm.flatness_thr_);
 
@@ -80,7 +86,7 @@ public:
         ROS_INFO("Cloud topic: %s", cloud_topic_.c_str());
         ROS_INFO("Num of Iteration: %d", num_iter_);
         ROS_INFO("Num of LPR: %d", num_lpr_);
-        ROS_INFO("Num of min. points: %d", num_min_pts_);
+        ROS_INFO("Num of min. points: %ld", num_min_pts_);
         ROS_INFO("Seeds Threshold: %f", th_seeds_);
         ROS_INFO("Distance Threshold: %f", th_dist_);
         ROS_INFO("Max. range: %f", max_range_);
@@ -88,10 +94,10 @@ public:
         ROS_INFO("Normal vector threshold: %f", uprightness_thr_);
         ROS_INFO("adaptive_seed_selection_margin: %f", adaptive_seed_selection_margin_);
         ROS_INFO("Num. zones: %ld", czm.num_zones_);
-        ROS_INFO_STREAM((boost::format("Num. sectors: %d, %d, %d, %d") % czm.num_sectors_each_zone_[0] % czm.num_sectors_each_zone_[1] %
+        ROS_INFO_STREAM((boost::format("Num. sectors: %ld, %ld, %ld, %ld") % czm.num_sectors_each_zone_[0] % czm.num_sectors_each_zone_[1] %
                  czm.num_sectors_each_zone_[2] %
                  czm.num_sectors_each_zone_[3]).str());
-        ROS_INFO_STREAM((boost::format("Num. rings: %01d, %01d, %01d, %01d") % czm.num_rings_each_zone_[0] %
+        ROS_INFO_STREAM((boost::format("Num. rings: %01ld, %01ld, %01ld, %01ld") % czm.num_rings_each_zone_[0] %
                  czm.num_rings_each_zone_[1] %
                  czm.num_rings_each_zone_[2] %
                  czm.num_rings_each_zone_[3]).str());
@@ -141,7 +147,7 @@ public:
     double sensor_height_;
     int num_iter_;
     int num_lpr_;
-    int num_min_pts_;
+    size_t num_min_pts_;
     double th_seeds_;
     double th_dist_;
     double th_seeds_v_;
@@ -165,8 +171,8 @@ public:
     struct CZM
     {
         size_t num_zones_;
-        std::vector<int> num_sectors_each_zone_;
-        std::vector<int> num_rings_each_zone_;
+        std::vector<size_t> num_sectors_each_zone_;
+        std::vector<size_t> num_rings_each_zone_;
         std::vector<double> elevation_thr_;
         std::vector<double> flatness_thr_;
     } czm;
@@ -199,8 +205,8 @@ private:
         }
         cloud_topic_ = config.cloud_topic;
 
-        auto num_sectors_each_zone = convert_string_to_vector<int>(config.czm_num_sectors_each_zone);
-        auto num_rings_each_zone = convert_string_to_vector<int>(config.czm_num_rings_each_zone);
+        auto num_sectors_each_zone = convert_string_to_vector<size_t>(config.czm_num_sectors_each_zone);
+        auto num_rings_each_zone = convert_string_to_vector<size_t>(config.czm_num_rings_each_zone);
         auto elevation_thr = convert_string_to_vector<double>(config.czm_elevation_thresholds);
         auto flatness_thr = convert_string_to_vector<double>(config.czm_flatness_thresholds);;
         if (czm.num_sectors_each_zone_ != num_sectors_each_zone || \

--- a/include/patchworkpp/params.hpp
+++ b/include/patchworkpp/params.hpp
@@ -8,118 +8,201 @@
 #include <dynamic_reconfigure/server.h>
 #include <patchworkpp/PatchworkppConfig.h>
 
-class ParamsNh
-{
+class ParamsNh {
 public:
-  ParamsNh() {
-    auto f = boost::bind(&ParamsNh::reconfigure_callback, this, _1, _2);
-    server_.setCallback(f);
-    validate();
-  }
+    ParamsNh() {
+        auto f = boost::bind(&ParamsNh::reconfigure_callback, this, _1, _2);
+        server_.setCallback(f);
+        validate();
+    }
 
-  ParamsNh(const ros::NodeHandle& nh) {
-    nh.param("verbose", verbose_, false);
-    nh.param("sensor_height", sensor_height_, 1.723);
-    nh.param("num_iter", num_iter_, 3);
-    nh.param("num_lpr", num_lpr_, 20);
-    nh.param("num_min_pts", num_min_pts_, 10);
-    nh.param("th_seeds", th_seeds_, 0.4);
-    nh.param("th_dist", th_dist_, 0.3);
-    nh.param("th_seeds_v", th_seeds_v_, 0.4);
-    nh.param("th_dist_v", th_dist_v_, 0.3);
-    nh.param("max_r", max_range_, 80.0);
-    nh.param("min_r", min_range_, 2.7);
-    nh.param("uprightness_thr", uprightness_thr_, 0.5);
-    nh.param("adaptive_seed_selection_margin", adaptive_seed_selection_margin_, -1.1);
-    nh.param("RNR_ver_angle_thr", RNR_ver_angle_thr_, -15.0);
-    nh.param("RNR_intensity_thr", RNR_intensity_thr_, 0.2);
-    nh.param("max_flatness_storage", max_flatness_storage_, 1000);
-    nh.param("max_elevation_storage", max_elevation_storage_, 1000);
-    nh.param("enable_RNR", enable_RNR_, true);
-    nh.param("enable_RVPF", enable_RVPF_, true);
-    nh.param("enable_TGR", enable_TGR_, true);
+    ParamsNh(const ros::NodeHandle& nh) {
+        nh.param("verbose", verbose_, false);
+        nh.param("sensor_height", sensor_height_, 1.723);
+        nh.param("num_iter", num_iter_, 3);
+        nh.param("num_lpr", num_lpr_, 20);
+        nh.param("num_min_pts", num_min_pts_, 10);
+        nh.param("th_seeds", th_seeds_, 0.4);
+        nh.param("th_dist", th_dist_, 0.3);
+        nh.param("th_seeds_v", th_seeds_v_, 0.4);
+        nh.param("th_dist_v", th_dist_v_, 0.3);
+        nh.param("max_r", max_range_, 80.0);
+        nh.param("min_r", min_range_, 2.7);
+        nh.param("uprightness_thr", uprightness_thr_, 0.5);
+        nh.param("adaptive_seed_selection_margin", adaptive_seed_selection_margin_, -1.1);
+        nh.param("RNR_ver_angle_thr", RNR_ver_angle_thr_, -15.0);
+        nh.param("RNR_intensity_thr", RNR_intensity_thr_, 0.2);
+        nh.param("max_flatness_storage", max_flatness_storage_, 1000);
+        nh.param("max_elevation_storage", max_elevation_storage_, 1000);
+        nh.param("enable_RNR", enable_RNR_, true);
+        nh.param("enable_RVPF", enable_RVPF_, true);
+        nh.param("enable_TGR", enable_TGR_, true);
 
-    // CZM denotes 'Concentric Zone Model'. Please refer to our paper
-    nh.getParam("czm/num_zones", czm.num_zones_);
-    nh.getParam("czm/num_sectors_each_zone", czm.num_sectors_each_zone_);
-    nh.getParam("czm/num_rings_each_zone", czm.num_rings_each_zone_);
-    nh.getParam("czm/elevation_thresholds", czm.elevation_thresholds_);
-    nh.getParam("czm/flatness_thresholds", czm.flatness_thresholds_);
+        // CZM denotes 'Concentric Zone Model'. Please refer to our paper
+        nh.getParam("czm/num_zones", czm.num_zones_);
+        nh.getParam("czm/num_sectors_each_zone", czm.num_sectors_each_zone_);
+        nh.getParam("czm/num_rings_each_zone", czm.num_rings_each_zone_);
+        nh.getParam("czm/elevation_thresholds", czm.elevation_thr_);
+        nh.getParam("czm/flatness_thresholds", czm.flatness_thr_);
 
-    initialized_ = true;
-    validate();
-  }
+        validate();
 
-  void print_params() const {
-    ROS_INFO("Sensor Height: %f", sensor_height_);
-    ROS_INFO("Num of Iteration: %d", num_iter_);
-    ROS_INFO("Num of LPR: %d", num_lpr_);
-    ROS_INFO("Num of min. points: %d", num_min_pts_);
-    ROS_INFO("Seeds Threshold: %f", th_seeds_);
-    ROS_INFO("Distance Threshold: %f", th_dist_);
-    ROS_INFO("Max. range:: %f", max_range_);
-    ROS_INFO("Min. range:: %f", min_range_);
-    ROS_INFO("Normal vector threshold: %f", uprightness_thr_);
-    ROS_INFO("adaptive_seed_selection_margin: %f", adaptive_seed_selection_margin_);
-  }
+        num_rings_of_interest_ = czm.elevation_thr_.size();
+
+        auto min_range_z2 = (7 * min_range_ + max_range_) / 8.0;
+        auto min_range_z3 = (3 * min_range_ + max_range_) / 4.0;
+        auto min_range_z4 = (min_range_ + max_range_) / 2.0;
+
+        min_ranges_ = {min_range_, min_range_z2, min_range_z3, min_range_z4};
+        ring_sizes_ = {(min_range_z2 - min_range_) / czm.num_rings_each_zone_.at(0),
+                      (min_range_z3 - min_range_z2) / czm.num_rings_each_zone_.at(1),
+                      (min_range_z4 - min_range_z3) / czm.num_rings_each_zone_.at(2),
+                      (max_range_ - min_range_z4) / czm.num_rings_each_zone_.at(3)};
+        sector_sizes_ = {2 * M_PI / czm.num_sectors_each_zone_.at(0), 2 * M_PI / czm.num_sectors_each_zone_.at(1),
+                        2 * M_PI / czm.num_sectors_each_zone_.at(2),
+                        2 * M_PI / czm.num_sectors_each_zone_.at(3)};
+
+        initialized_ = true;
+        
+    }
+
+    void print_params() const {
+        ROS_INFO("Sensor Height: %f", sensor_height_);
+        ROS_INFO("Num of Iteration: %d", num_iter_);
+        ROS_INFO("Num of LPR: %d", num_lpr_);
+        ROS_INFO("Num of min. points: %d", num_min_pts_);
+        ROS_INFO("Seeds Threshold: %f", th_seeds_);
+        ROS_INFO("Distance Threshold: %f", th_dist_);
+        ROS_INFO("Max. range:: %f", max_range_);
+        ROS_INFO("Min. range:: %f", min_range_);
+        ROS_INFO("Normal vector threshold: %f", uprightness_thr_);
+        ROS_INFO("adaptive_seed_selection_margin: %f", adaptive_seed_selection_margin_);
+        ROS_INFO("Num. zones: %d", czm.num_zones_);
+        ROS_INFO_STREAM((boost::format("Num. sectors: %d, %d, %d, %d") % czm.num_sectors_each_zone_[0] % czm.num_sectors_each_zone_[1] %
+                 czm.num_sectors_each_zone_[2] %
+                 czm.num_sectors_each_zone_[3]).str());
+        ROS_INFO_STREAM((boost::format("Num. rings: %01d, %01d, %01d, %01d") % czm.num_rings_each_zone_[0] %
+                 czm.num_rings_each_zone_[1] %
+                 czm.num_rings_each_zone_[2] %
+                 czm.num_rings_each_zone_[3]).str());
+        ROS_INFO_STREAM((boost::format("elevation_thr_: %0.4f, %0.4f, %0.4f, %0.4f ") % czm.elevation_thr_[0] % czm.elevation_thr_[1] %
+                 czm.elevation_thr_[2] %
+                 czm.elevation_thr_[3]).str());
+        ROS_INFO_STREAM((boost::format("flatness_thr_: %0.4f, %0.4f, %0.4f, %0.4f ") % czm.flatness_thr_[0] % czm.flatness_thr_[1] %
+                 czm.flatness_thr_[2] %
+                 czm.flatness_thr_[3]).str());
+    }
 
     bool validate() {
-    return  check(czm.num_zones_ == czm.num_sectors_each_zone_.size(), "num_zones and length of num_sectors_each_zone must match") &&\
-            check(czm.num_zones_ == czm.num_rings_each_zone_.size(), "num_zones and length of num_rings_each_zone must match") &&\
-            check(czm.num_zones_ == czm.elevation_thresholds_.size(), "num_zones and length of elevation_thresholds must match") &&\
-            check(czm.num_zones_ == czm.flatness_thresholds_.size(), "num_zones and length of flatness_thresholds must match");
-  }
+        return  check(czm.num_zones_ != 4, "Number of zones must be four!") &&\
+                check(czm.num_zones_ == czm.num_sectors_each_zone_.size(), "num_zones and length of num_sectors_each_zone must match") &&\
+                check(czm.num_zones_ == czm.num_rings_each_zone_.size(), "num_zones and length of num_rings_each_zone must match") &&\
+                check(czm.num_zones_ == czm.elevation_thr_.size(), "num_zones and length of elevation_thresholds must match") &&\
+                check(czm.num_zones_ == czm.flatness_thr_.size(), "num_zones and length of flatness_thresholds must match");
+    }
+
+    std::string mode_;
+    bool initialized_;
+    bool verbose_;
+    double sensor_height_;
+    int num_iter_;
+    int num_lpr_;
+    int num_min_pts_;
+    double th_seeds_;
+    double th_dist_;
+    double th_seeds_v_;
+    double th_dist_v_;
+    double max_range_;
+    double min_range_;
+    double uprightness_thr_;
+    double adaptive_seed_selection_margin_;
+    double RNR_ver_angle_thr_;
+    double RNR_intensity_thr_;
+    int max_flatness_storage_;
+    int max_elevation_storage_;
+    bool enable_RNR_;
+    bool enable_RVPF_;
+    bool enable_TGR_;
+    size_t num_rings_of_interest_;
+    std::vector<double> min_ranges_;
+    std::vector<double> ring_sizes_;
+    std::vector<double> sector_sizes_;
+
+    struct CZM
+    {
+        int num_zones_;
+        std::vector<int> num_sectors_each_zone_;
+        std::vector<int> num_rings_each_zone_;
+        std::vector<double> elevation_thr_;
+        std::vector<double> flatness_thr_;
+    } czm;
 
 private:
-  void reconfigure_callback(const patchworkpp::PatchworkppConfig& config, uint32_t level) {
-    verbose_ = config.verbose;
-    sensor_height_ = config.sensor_height;
-    num_iter_ = config.num_iter;
-    num_lpr_ = config.num_lpr;
-    num_min_pts_ = config.num_min_pts;
-    th_seeds_ = config.th_seeds;
-    th_dist_ = config.th_dist;
-    th_seeds_v_ = config.th_seeds_v;
-    th_dist_v_ = config.th_dist_v;
-    uprightness_thr_ = config.uprightness_thr;
-    adaptive_seed_selection_margin_ = config.adaptive_seed_selection_margin;
-    RNR_ver_angle_thr_ = config.RNR_ver_angle_thr;
-    RNR_intensity_thr_ = config.RNR_intensity_thr;
-    enable_RNR_ = config.enable_RNR;
-    enable_RVPF_ = config.enable_RVPF;
-    enable_TGR_ = config.enable_TGR;
+    void reconfigure_callback(const patchworkpp::PatchworkppConfig& config, uint32_t level) {
+        verbose_ = config.verbose;
+        sensor_height_ = config.sensor_height;
+        num_iter_ = config.num_iter;
+        num_lpr_ = config.num_lpr;
+        num_min_pts_ = config.num_min_pts;
+        th_seeds_ = config.th_seeds;
+        th_dist_ = config.th_dist;
+        th_seeds_v_ = config.th_seeds_v;
+        th_dist_v_ = config.th_dist_v;
+        uprightness_thr_ = config.uprightness_thr;
+        adaptive_seed_selection_margin_ = config.adaptive_seed_selection_margin;
+        RNR_ver_angle_thr_ = config.RNR_ver_angle_thr;
+        RNR_intensity_thr_ = config.RNR_intensity_thr;
+        enable_RNR_ = config.enable_RNR;
+        enable_RVPF_ = config.enable_RVPF;
+        enable_TGR_ = config.enable_TGR;
 
-    czm.num_zones_ = config.czm_num_zones;
-    czm.num_sectors_each_zone_ = convert_string_to_vector<int>(config.czm_num_sectors_each_zone);
-    czm.num_rings_each_zone_ = convert_string_to_vector<int>(config.czm_num_rings_each_zone);
-    czm.elevation_thresholds_ = convert_string_to_vector<double>(config.czm_elevation_thresholds);
-    czm.flatness_thresholds_ = convert_string_to_vector<double>(config.czm_flatness_thresholds);
+        czm.num_zones_ = config.czm_num_zones;
+        czm.num_sectors_each_zone_ = convert_string_to_vector<int>(config.czm_num_sectors_each_zone);
+        czm.num_rings_each_zone_ = convert_string_to_vector<int>(config.czm_num_rings_each_zone);
+        czm.elevation_thr_ = convert_string_to_vector<double>(config.czm_elevation_thresholds);
+        czm.flatness_thr_ = convert_string_to_vector<double>(config.czm_flatness_thresholds);
 
-    ROS_INFO("Updated params");
-    initialized_ = true;
-    validate();
-  }
+        num_rings_of_interest_ = czm.elevation_thr_.size();
+
+        auto min_range_z2 = (7 * min_range_ + max_range_) / 8.0;
+        auto min_range_z3 = (3 * min_range_ + max_range_) / 4.0;
+        auto min_range_z4 = (min_range_ + max_range_) / 2.0;
+
+        validate();
+
+        min_ranges_ = {min_range_, min_range_z2, min_range_z3, min_range_z4};
+        ring_sizes_ = {(min_range_z2 - min_range_) / czm.num_rings_each_zone_.at(0),
+                      (min_range_z3 - min_range_z2) / czm.num_rings_each_zone_.at(1),
+                      (min_range_z4 - min_range_z3) / czm.num_rings_each_zone_.at(2),
+                      (max_range_ - min_range_z4) / czm.num_rings_each_zone_.at(3)};
+        sector_sizes_ = {2 * M_PI / czm.num_sectors_each_zone_.at(0), 2 * M_PI / czm.num_sectors_each_zone_.at(1),
+                        2 * M_PI / czm.num_sectors_each_zone_.at(2),
+                        2 * M_PI / czm.num_sectors_each_zone_.at(3)};
+
+        ROS_INFO("Updated params");
+        initialized_ = true;
+    }
 
 
-  template <typename T>
-  std::vector<T> convert_string_to_vector(const std::string& str, char separator = ',') {
-      std::vector<T> result;
-      std::istringstream iss(str);
-      std::string token;
-      
-      while (std::getline(iss, token, separator)) {
-        token = std::regex_replace(token, std::regex("\\s+"), "");
-        T num;
-        std::stringstream stream(token);
-        stream >> num;
-        if (stream.fail()) {
-            ROS_WARN_STREAM("Can't convert " << token << " to number");
-            return result;
+    template <typename T>
+    std::vector<T> convert_string_to_vector(const std::string& str, char separator = ',') {
+        std::vector<T> result;
+        std::istringstream iss(str);
+        std::string token;
+        
+        while (std::getline(iss, token, separator)) {
+            token = std::regex_replace(token, std::regex("\\s+"), "");
+            T num;
+            std::stringstream stream(token);
+            stream >> num;
+            if (stream.fail()) {
+                ROS_WARN_STREAM("Can't convert " << token << " to number");
+                return result;
+            }
         }
-      }
-      
-      return result;
-  }
+        
+        return result;
+    }
 
 
   bool check(bool assertion, std::string description) {
@@ -130,38 +213,6 @@ private:
 
     return true;
   }
-
-  std::string mode_;
-  bool initialized_;
-  bool verbose_;
-  double sensor_height_;
-  int num_iter_;
-  int num_lpr_;
-  int num_min_pts_;
-  double th_seeds_;
-  double th_dist_;
-  double th_seeds_v_;
-  double th_dist_v_;
-  double max_range_;
-  double min_range_;
-  double uprightness_thr_;
-  double adaptive_seed_selection_margin_;
-  double RNR_ver_angle_thr_;
-  double RNR_intensity_thr_;
-  int max_flatness_storage_;
-  int max_elevation_storage_;
-  bool enable_RNR_;
-  bool enable_RVPF_;
-  bool enable_TGR_;
-  
-  struct CZM
-  {
-    int num_zones_;
-    std::vector<int> num_sectors_each_zone_;
-    std::vector<int> num_rings_each_zone_;
-    std::vector<double> elevation_thresholds_;
-    std::vector<double> flatness_thresholds_;
-  } czm;
 
   dynamic_reconfigure::Server<patchworkpp::PatchworkppConfig> server_;
 };

--- a/include/patchworkpp/params.hpp
+++ b/include/patchworkpp/params.hpp
@@ -56,22 +56,9 @@ public:
 
         czm.num_zones_ = 4;
         params_valid_ = validate();
-
-        num_rings_of_interest_ = czm.elevation_thr_.size();
-
-        auto min_range_z2 = (7 * min_range_ + max_range_) / 8.0;
-        auto min_range_z3 = (3 * min_range_ + max_range_) / 4.0;
-        auto min_range_z4 = (min_range_ + max_range_) / 2.0;
-
-        min_ranges_ = {min_range_, min_range_z2, min_range_z3, min_range_z4};
-        ring_sizes_ = {(min_range_z2 - min_range_) / czm.num_rings_each_zone_.at(0),
-                      (min_range_z3 - min_range_z2) / czm.num_rings_each_zone_.at(1),
-                      (min_range_z4 - min_range_z3) / czm.num_rings_each_zone_.at(2),
-                      (max_range_ - min_range_z4) / czm.num_rings_each_zone_.at(3)};
-        sector_sizes_ = {2 * M_PI / czm.num_sectors_each_zone_.at(0), 2 * M_PI / czm.num_sectors_each_zone_.at(1),
-                        2 * M_PI / czm.num_sectors_each_zone_.at(2),
-                        2 * M_PI / czm.num_sectors_each_zone_.at(3)};
-
+        if (params_valid_) {
+            set_ranges_rings_sectors();
+        }
     }
 
     void print_params() const {
@@ -224,20 +211,7 @@ private:
         params_valid_ = validate();
         if (params_valid_)
         {
-            num_rings_of_interest_ = czm.elevation_thr_.size();
-
-            auto min_range_z2 = (7 * min_range_ + max_range_) / 8.0;
-            auto min_range_z3 = (3 * min_range_ + max_range_) / 4.0;
-            auto min_range_z4 = (min_range_ + max_range_) / 2.0;
-
-            min_ranges_ = {min_range_, min_range_z2, min_range_z3, min_range_z4};
-            ring_sizes_ = {(min_range_z2 - min_range_) / czm.num_rings_each_zone_.at(0),
-                        (min_range_z3 - min_range_z2) / czm.num_rings_each_zone_.at(1),
-                        (min_range_z4 - min_range_z3) / czm.num_rings_each_zone_.at(2),
-                        (max_range_ - min_range_z4) / czm.num_rings_each_zone_.at(3)};
-            sector_sizes_ = {2 * M_PI / czm.num_sectors_each_zone_.at(0), 2 * M_PI / czm.num_sectors_each_zone_.at(1),
-                            2 * M_PI / czm.num_sectors_each_zone_.at(2),
-                            2 * M_PI / czm.num_sectors_each_zone_.at(3)};
+            set_ranges_rings_sectors();
             ROS_INFO("Updated params");
         } else {
             ROS_WARN("Parameter update failed");
@@ -264,6 +238,23 @@ private:
         }
         
         return result;
+    }
+
+    void set_ranges_rings_sectors() {
+        num_rings_of_interest_ = czm.elevation_thr_.size();
+
+        auto min_range_z2 = (7 * min_range_ + max_range_) / 8.0;
+        auto min_range_z3 = (3 * min_range_ + max_range_) / 4.0;
+        auto min_range_z4 = (min_range_ + max_range_) / 2.0;
+
+        min_ranges_ = {min_range_, min_range_z2, min_range_z3, min_range_z4};
+        ring_sizes_ = {(min_range_z2 - min_range_) / czm.num_rings_each_zone_.at(0),
+                      (min_range_z3 - min_range_z2) / czm.num_rings_each_zone_.at(1),
+                      (min_range_z4 - min_range_z3) / czm.num_rings_each_zone_.at(2),
+                      (max_range_ - min_range_z4) / czm.num_rings_each_zone_.at(3)};
+        sector_sizes_ = {2 * M_PI / czm.num_sectors_each_zone_.at(0), 2 * M_PI / czm.num_sectors_each_zone_.at(1),
+                        2 * M_PI / czm.num_sectors_each_zone_.at(2),
+                        2 * M_PI / czm.num_sectors_each_zone_.at(3)};
     }
 
 

--- a/include/patchworkpp/patchworkpp.hpp
+++ b/include/patchworkpp/patchworkpp.hpp
@@ -135,7 +135,7 @@ private:
     Eigen::Matrix3f cov_;
     Eigen::Vector4f pc_mean_;
 
-    queue<int> noise_idxs_;
+    queue<size_t> noise_idxs_;
 
     vector<Zone> ConcentricZoneModel_;
 
@@ -966,8 +966,8 @@ double PatchWorkpp<PointT>::xy2radius(const double &x, const double &y) {
 template<typename PointT> inline
 void PatchWorkpp<PointT>::pc2czm(const pcl::PointCloud<PointT> &src, std::vector<Zone> &czm, pcl::PointCloud<PointT> &cloud_nonground) {
 
-    for (int i=0; i<src.size(); i++) {
-        if ((!noise_idxs_.empty()) &&(i == noise_idxs_.front())) {
+    for (size_t i = 0; i < src.size(); i++) {
+        if ((!noise_idxs_.empty()) && (i == noise_idxs_.front())) {
             noise_idxs_.pop();
             continue;
         }
@@ -984,8 +984,8 @@ void PatchWorkpp<PointT>::pc2czm(const pcl::PointCloud<PointT> &src, std::vector
             else if ( r < params_.min_ranges_[3] ) zone_idx = 2;
             else zone_idx = 3;
 
-            int ring_idx = min(static_cast<int>(((r - params_.min_ranges_[zone_idx]) / params_.ring_sizes_[zone_idx])), params_.czm.num_rings_each_zone_[zone_idx] - 1);
-            int sector_idx = min(static_cast<int>((theta / params_.sector_sizes_[zone_idx])), params_.czm.num_sectors_each_zone_[zone_idx] - 1);
+            size_t ring_idx = min(static_cast<size_t>(((r - params_.min_ranges_[zone_idx]) / params_.ring_sizes_[zone_idx])), params_.czm.num_rings_each_zone_[zone_idx] - 1);
+            size_t sector_idx = min(static_cast<size_t>((theta / params_.sector_sizes_[zone_idx])), params_.czm.num_sectors_each_zone_[zone_idx] - 1);
 
             czm[zone_idx][ring_idx][sector_idx].points.emplace_back(pt);
         }

--- a/include/patchworkpp/utils.hpp
+++ b/include/patchworkpp/utils.hpp
@@ -70,7 +70,7 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(PointXYZILID,
 
 
 void PointXYZILID2XYZI(pcl::PointCloud<PointXYZILID>& src,
-                       pcl::PointCloud<pcl::PointXYZI>::Ptr dst){
+                       pcl::PointCloud<pcl::PointXYZI>::Ptr dst) {
   dst->points.clear();
   for (const auto &pt: src.points){
     pcl::PointXYZI pt_xyzi;
@@ -86,7 +86,7 @@ std::vector<int> ground_classes = {ROAD, PARKING, SIDEWALKR, OTHER_GROUND, LANE_
 std::vector<int> ground_classes_except_terrain = {ROAD, PARKING, SIDEWALKR, OTHER_GROUND, LANE_MARKING};
 std::vector<int> traversable_ground_classes = {ROAD, PARKING, LANE_MARKING, OTHER_GROUND};
 
-int count_num_ground(const pcl::PointCloud<PointXYZILID>& pc){
+int count_num_ground(const pcl::PointCloud<PointXYZILID>& pc) {
   int num_ground = 0;
 
   std::vector<int>::iterator iter;
@@ -94,17 +94,19 @@ int count_num_ground(const pcl::PointCloud<PointXYZILID>& pc){
   for (auto const& pt: pc.points){
     iter = std::find(ground_classes.begin(), ground_classes.end(), pt.label);
     if (iter != ground_classes.end()){ // corresponding class is in ground classes
-      if (pt.label == VEGETATION){
-        if (pt.z < VEGETATION_THR){
+      if (pt.label == VEGETATION) {
+        if (pt.z < VEGETATION_THR) {
            num_ground ++;
         }
-      }else num_ground ++;
+      } else { 
+        num_ground ++;
+      }
     }
   }
   return num_ground;
 }
 
-int count_num_ground_without_vegetation(const pcl::PointCloud<PointXYZILID>& pc){
+int count_num_ground_without_vegetation(const pcl::PointCloud<PointXYZILID>& pc) {
   int num_ground = 0;
 
   std::vector<int>::iterator iter;
@@ -113,34 +115,35 @@ int count_num_ground_without_vegetation(const pcl::PointCloud<PointXYZILID>& pc)
 
   for (auto const& pt: pc.points){
     iter = std::find(classes.begin(), classes.end(), pt.label);
-    if (iter != classes.end()){ // corresponding class is in ground classes
+    if (iter != classes.end()) { // corresponding class is in ground classes
       num_ground ++;
     }
   }
   return num_ground;
 }
 
-std::map<int, int> set_initial_gt_counts(std::vector<int>& gt_classes){
+std::map<int, int> set_initial_gt_counts(std::vector<int>& gt_classes) {
   map<int, int> gt_counts;
-  for (int i = 0; i< gt_classes.size(); ++i){
+  for (size_t i = 0; i < gt_classes.size(); ++i) {
     gt_counts.insert(pair<int,int>(gt_classes.at(i), 0));
   }
   return gt_counts;
 }
 
-std::map<int, int> count_num_each_class(const pcl::PointCloud<PointXYZILID>& pc){
-  int num_ground = 0;
+std::map<int, int> count_num_each_class(const pcl::PointCloud<PointXYZILID>& pc) {
   auto gt_counts = set_initial_gt_counts(ground_classes);
   std::vector<int>::iterator iter;
 
   for (auto const& pt: pc.points){
     iter = std::find(ground_classes.begin(), ground_classes.end(), pt.label);
     if (iter != ground_classes.end()){ // corresponding class is in ground classes
-      if (pt.label == VEGETATION){
-        if (pt.z < VEGETATION_THR){
+      if (pt.label == VEGETATION) {
+        if (pt.z < VEGETATION_THR) {
            gt_counts.find(pt.label)->second++;
         }
-      }else gt_counts.find(pt.label)->second++;
+      } else {
+        gt_counts.find(pt.label)->second++;
+      }
     }
   }
   return gt_counts;
@@ -165,16 +168,20 @@ void discern_ground(const pcl::PointCloud<PointXYZILID>& src, pcl::PointCloud<Po
   ground.clear();
   non_ground.clear();
   std::vector<int>::iterator iter;
-  for (auto const& pt: src.points){
+  for (auto const& pt: src.points) {
     if (pt.label == UNLABELED || pt.label == OUTLIER) continue;
     iter = std::find(ground_classes.begin(), ground_classes.end(), pt.label);
     if (iter != ground_classes.end()){ // corresponding class is in ground classes
-      if (pt.label == VEGETATION){
-        if (pt.z < VEGETATION_THR){
+      if (pt.label == VEGETATION) {
+        if (pt.z < VEGETATION_THR) {
           ground.push_back(pt);
-        }else non_ground.push_back(pt);
-      }else  ground.push_back(pt);
-    }else{
+        } else {
+          non_ground.push_back(pt);
+        }
+      } else { 
+        ground.push_back(pt);
+      }
+    } else {
       non_ground.push_back(pt);
     }
   }
@@ -184,12 +191,12 @@ void discern_ground_without_vegetation(const pcl::PointCloud<PointXYZILID>& src,
   ground.clear();
   non_ground.clear();
   std::vector<int>::iterator iter;
-  for (auto const& pt: src.points){
+  for (auto const& pt: src.points) {
     if (pt.label == UNLABELED || pt.label == OUTLIER) continue;
     iter = std::find(ground_classes.begin(), ground_classes.end(), pt.label);
     if (iter != ground_classes.end()){ // corresponding class is in ground classes
       if (pt.label != VEGETATION) ground.push_back(pt);
-    }else{
+    } else {
       non_ground.push_back(pt);
     }
   }
@@ -200,16 +207,16 @@ void calculate_precision_recall(const pcl::PointCloud<PointXYZILID>& pc_curr,
                                 pcl::PointCloud<PointXYZILID>& ground_estimated,
                                 double & precision,
                                 double& recall,
-                                bool consider_outliers=true){
+                                bool consider_outliers=true) {
 
   int num_ground_est = ground_estimated.points.size();
   int num_ground_gt = count_num_ground(pc_curr);
   int num_TP = count_num_ground(ground_estimated);
-  if (consider_outliers){
+  if (consider_outliers) {
     int num_outliers_est = count_num_outliers(ground_estimated);
     precision = (double)(num_TP)/(num_ground_est - num_outliers_est) * 100;
     recall = (double)(num_TP)/num_ground_gt * 100;
-  }else{
+  } else {
     precision = (double)(num_TP)/num_ground_est * 100;
     recall = (double)(num_TP)/num_ground_gt * 100;
   }
@@ -219,28 +226,27 @@ void calculate_precision_recall_without_vegetation(const pcl::PointCloud<PointXY
                                                    pcl::PointCloud<PointXYZILID>& ground_estimated,
                                                    double & precision,
                                                    double& recall,
-                                                   bool consider_outliers=true){
+                                                   bool consider_outliers=true) {
   int num_veg = 0;
-  for (auto const& pt: ground_estimated.points)
-  {
+  for (auto const& pt: ground_estimated.points) {
     if (pt.label == VEGETATION) num_veg++;
   }
 
   int num_ground_est = ground_estimated.size() - num_veg;
   int num_ground_gt = count_num_ground_without_vegetation(pc_curr);
   int num_TP = count_num_ground_without_vegetation(ground_estimated);
-  if (consider_outliers){
+  if (consider_outliers) {
     int num_outliers_est = count_num_outliers(ground_estimated);
     precision = (double)(num_TP)/(num_ground_est - num_outliers_est) * 100;
     recall = (double)(num_TP)/num_ground_gt * 100;
-  }else{
+  } else {
     precision = (double)(num_TP)/num_ground_est * 100;
     recall = (double)(num_TP)/num_ground_gt * 100;
   }
 }
 
 
-void save_all_labels(const pcl::PointCloud<PointXYZILID>& pc, string ABS_DIR, string seq, int count){
+void save_all_labels(const pcl::PointCloud<PointXYZILID>& pc, string ABS_DIR, string seq, int count) {
 
   std::string count_str = std::to_string(count);
   std::string count_str_padded = std::string(NUM_ZEROS - count_str.length(), '0') + count_str;
@@ -285,10 +291,10 @@ void save_all_labels(const pcl::PointCloud<PointXYZILID>& pc, string ABS_DIR, st
     else if (pt.label == 259) labels[33]++;
   }
 
-  for (uint8_t i=0; i < NUM_ALL_CLASSES;++i){
-    if (i!=33){
+  for (uint8_t i=0; i < NUM_ALL_CLASSES;++i) {
+    if (i!=33) {
       sc_output<<labels[i]<<",";
-    }else{
+    } else {
       sc_output<<labels[i]<<endl;
     }
   }
@@ -297,7 +303,7 @@ void save_all_labels(const pcl::PointCloud<PointXYZILID>& pc, string ABS_DIR, st
 
 void save_all_accuracy(const pcl::PointCloud<PointXYZILID>& pc_curr,
                       pcl::PointCloud<PointXYZILID>& ground_estimated, string acc_filename,
-                      double& accuracy, map<int, int>&pc_curr_gt_counts, map<int, int>&g_est_gt_counts){
+                      double& accuracy, map<int, int>&pc_curr_gt_counts, map<int, int>&g_est_gt_counts) {
 
 
 //  std::cout<<"debug: "<<acc_filename<<std::endl;
@@ -319,7 +325,7 @@ void save_all_accuracy(const pcl::PointCloud<PointXYZILID>& pc_curr,
   g_est_gt_counts = count_num_each_class(ground_estimated);
 
   // save output
-  for (auto const& class_id: ground_classes){
+  for (auto const& class_id: ground_classes) {
     sc_output2<<g_est_gt_counts.find(class_id)->second<<","<<pc_curr_gt_counts.find(class_id)->second<<",";
   }
   sc_output2<<accuracy<<endl;
@@ -329,28 +335,28 @@ void save_all_accuracy(const pcl::PointCloud<PointXYZILID>& pc_curr,
 
 void pc2pcdfile(const pcl::PointCloud<PointXYZILID>& TP, const pcl::PointCloud<PointXYZILID>& FP,
                 const pcl::PointCloud<PointXYZILID>& FN, const pcl::PointCloud<PointXYZILID>& TN,
-                std::string pcd_filename){
+                std::string pcd_filename) {
   pcl::PointCloud<pcl::PointXYZI> pc_out;
 
-  for (auto const pt: TP.points){
+  for (auto const pt: TP.points) {
     pcl::PointXYZI pt_est;
     pt_est.x = pt.x; pt_est.y = pt.y; pt_est.z = pt.z;
     pt_est.intensity = TRUEPOSITIVE;
     pc_out.points.push_back(pt_est);
   }
-  for (auto const pt: FP.points){
+  for (auto const pt: FP.points) {
     pcl::PointXYZI pt_est;
     pt_est.x = pt.x; pt_est.y = pt.y; pt_est.z = pt.z;
     pt_est.intensity = FALSEPOSITIVE;
     pc_out.points.push_back(pt_est);
   }
-  for (auto const pt: FN.points){
+  for (auto const pt: FN.points) {
     pcl::PointXYZI pt_est;
     pt_est.x = pt.x; pt_est.y = pt.y; pt_est.z = pt.z;
     pt_est.intensity = FALSENEGATIVE;
     pc_out.points.push_back(pt_est);
   }
-  for (auto const pt: TN.points){
+  for (auto const pt: TN.points) {
     pcl::PointXYZI pt_est;
     pt_est.x = pt.x; pt_est.y = pt.y; pt_est.z = pt.z;
     pt_est.intensity = TRUENEGATIVE;

--- a/launch/demo.launch
+++ b/launch/demo.launch
@@ -3,7 +3,7 @@
 <arg name="cloud_topic" default="/kitti/velo/pointcloud"/>
 
   <node name="ground_segmentation" pkg="patchworkpp" type="demo" output="screen">
-    <rosparam command="load" file="$(find patchworkpp)/config/params.yaml" />
+    <rosparam command="load" file="$(find patchworkpp)/params/params.yaml" />
     <param name="cloud_topic" value="$(arg cloud_topic)"/>
   </node>
 

--- a/launch/demo.launch
+++ b/launch/demo.launch
@@ -1,6 +1,6 @@
 <launch>
 
-<arg name="cloud_topic" default="/velodyne_points"/>
+<arg name="cloud_topic" default="/kitti/velo/pointcloud"/>
 
   <node name="ground_segmentation" pkg="patchworkpp" type="demo" output="screen">
     <rosparam command="load" file="$(find patchworkpp)/params/params.yaml" />

--- a/launch/demo_reconf.launch
+++ b/launch/demo_reconf.launch
@@ -1,13 +1,8 @@
 <launch>
 
-  <arg name="cloud_topic" default="/velodyne_points"/>
-  
   <node name="rqt_conf_gui" pkg="rqt_reconfigure" type="rqt_reconfigure" output="screen"/>
 
-  <node name="ground_segmentation" pkg="patchworkpp" type="demo_reconf" output="screen">
-    <rosparam command="load" file="$(find patchworkpp)/params/params.yaml" />
-    <param name="cloud_topic" value="$(arg cloud_topic)"/>
-  </node>
+  <node name="ground_segmentation" pkg="patchworkpp" type="demo_reconf" output="screen"/>
 
   <node name="$(anon rviz)" pkg="rviz" type="rviz" args="-d $(find patchworkpp)/rviz/demo.rviz"/>
 

--- a/launch/demo_reconf.launch
+++ b/launch/demo_reconf.launch
@@ -1,8 +1,10 @@
 <launch>
 
-<arg name="cloud_topic" default="/velodyne_points"/>
+  <arg name="cloud_topic" default="/velodyne_points"/>
+  
+  <node name="rqt_conf_gui" pkg="rqt_reconfigure" type="rqt_reconfigure" output="screen"/>
 
-  <node name="ground_segmentation" pkg="patchworkpp" type="demo" output="screen">
+  <node name="ground_segmentation" pkg="patchworkpp" type="demo_reconf" output="screen">
     <rosparam command="load" file="$(find patchworkpp)/params/params.yaml" />
     <param name="cloud_topic" value="$(arg cloud_topic)"/>
   </node>

--- a/package.xml
+++ b/package.xml
@@ -31,7 +31,6 @@
   <build_depend>jsk_recognition_msgs</build_depend>
   <build_depend>laser_geometry</build_depend>
 
-
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->

--- a/params/params.yaml
+++ b/params/params.yaml
@@ -2,7 +2,8 @@ save_flag: true
 
 # patchworkpp:
 
-sensor_height: 1.2
+sensor_height: 1.723
+point_topic: /kitti/velo/pointcloud
 
 mode: "czm"
 verbose: false   # To check effect of uprightness/elevation/flatness
@@ -22,7 +23,6 @@ uprightness_thr: 0.707  # threshold of uprightness using in Ground Likelihood Es
 
 adaptive_seed_selection_margin: -1.2 # The points below the adaptive_seed_selection_margin * sensor_height are filtered
 czm:
-    num_zones: 4
     num_sectors_each_zone: [16, 32, 54, 32]
     num_rings_each_zone: [2, 4, 4, 4]
     elevation_thresholds:  [0.0, 0.0, 0.0, 0.0] # threshold of elevation for each ring using in GLE. Those values are updated adaptively.

--- a/params/params.yaml
+++ b/params/params.yaml
@@ -2,14 +2,14 @@ save_flag: true
 
 # patchworkpp:
 
-sensor_height: 1.723
+sensor_height: 1.2
 
 mode: "czm"
 verbose: false   # To check effect of uprightness/elevation/flatness
 visualize: true  # Ground Likelihood Estimation is visualized
 
 # Ground Plane Fitting parameters
-num_iter: 3             # Number of iterations for ground plane estimation using PCA.
+num_iter: 5             # Number of iterations for ground plane estimation using PCA.
 num_lpr: 20             # Maximum number of points to be selected as lowest points representative.
 num_min_pts: 10         # Minimum number of points to be estimated as ground plane in each patch.
 th_seeds: 0.3           # threshold for lowest point representatives using in initial seeds selection of ground points.
@@ -24,7 +24,7 @@ adaptive_seed_selection_margin: -1.2 # The points below the adaptive_seed_select
 czm:
     num_zones: 4
     num_sectors_each_zone: [16, 32, 54, 32]
-    mum_rings_each_zone: [2, 4, 4, 4]
+    num_rings_each_zone: [2, 4, 4, 4]
     elevation_thresholds:  [0.0, 0.0, 0.0, 0.0] # threshold of elevation for each ring using in GLE. Those values are updated adaptively.
     flatness_thresholds:  [0.0, 0.0, 0.0, 0.0]  # threshold of flatness for each ring using in GLE. Those values are updated adaptively.
 

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -54,9 +54,6 @@ int main(int argc, char**argv) {
     ros::NodeHandle nh;
     ros::NodeHandle pnh("~");
 
-    std::string cloud_topic;
-    pnh.param<string>("cloud_topic", cloud_topic, "/pointcloud");
-
     ROS_INFO("Operating patchwork++...");
     PatchworkppGroundSeg.reset(new PatchWorkpp<PointType>(pnh));
 
@@ -64,7 +61,7 @@ int main(int argc, char**argv) {
     pub_ground      = pnh.advertise<sensor_msgs::PointCloud2>("ground", 100, true);
     pub_non_ground  = pnh.advertise<sensor_msgs::PointCloud2>("nonground", 100, true);
 
-    ros::Subscriber sub_cloud = nh.subscribe(cloud_topic, 100, callbackCloud);
+    ros::Subscriber sub_cloud = nh.subscribe(PatchworkppGroundSeg->topic(), 100, callbackCloud);
 
 
     while (ros::ok())

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -57,7 +57,7 @@ int main(int argc, char**argv) {
     std::string cloud_topic;
     pnh.param<string>("cloud_topic", cloud_topic, "/pointcloud");
 
-    cout << "Operating patchwork++..." << endl;
+    ROS_INFO("Operating patchwork++...");
     PatchworkppGroundSeg.reset(new PatchWorkpp<PointType>(pnh));
 
     pub_cloud       = pnh.advertise<sensor_msgs::PointCloud2>("cloud", 100, true);

--- a/src/demo.cpp
+++ b/src/demo.cpp
@@ -38,14 +38,14 @@ void callbackCloud(const sensor_msgs::PointCloud2::Ptr &cloud_msg)
 
     pcl::fromROSMsg(*cloud_msg, pc_curr);
 
-    PatchworkppGroundSeg->estimate_ground(pc_curr, pc_ground, pc_non_ground, time_taken);
+    if (PatchworkppGroundSeg->estimate_ground(pc_curr, pc_ground, pc_non_ground, time_taken)) {
+        ROS_INFO_STREAM("\033[1;32m" << "Input PointCloud: " << pc_curr.size() << " -> Ground: " << pc_ground.size() <<  "/ NonGround: " << pc_non_ground.size()
+            << " (running_time: " << time_taken << " sec)" << "\033[0m");
 
-    ROS_INFO_STREAM("\033[1;32m" << "Input PointCloud: " << pc_curr.size() << " -> Ground: " << pc_ground.size() <<  "/ NonGround: " << pc_non_ground.size()
-         << " (running_time: " << time_taken << " sec)" << "\033[0m");
-
-    pub_cloud.publish(cloud2msg(pc_curr, cloud_msg->header.stamp, cloud_msg->header.frame_id));
-    pub_ground.publish(cloud2msg(pc_ground, cloud_msg->header.stamp, cloud_msg->header.frame_id));
-    pub_non_ground.publish(cloud2msg(pc_non_ground, cloud_msg->header.stamp, cloud_msg->header.frame_id));
+        pub_cloud.publish(cloud2msg(pc_curr, cloud_msg->header.stamp, cloud_msg->header.frame_id));
+        pub_ground.publish(cloud2msg(pc_ground, cloud_msg->header.stamp, cloud_msg->header.frame_id));
+        pub_non_ground.publish(cloud2msg(pc_non_ground, cloud_msg->header.stamp, cloud_msg->header.frame_id));
+    }
 }
 
 int main(int argc, char**argv) {

--- a/src/demo_reconf.cpp
+++ b/src/demo_reconf.cpp
@@ -3,6 +3,7 @@
 #define PCL_NO_PRECOMPILE
 
 #include <ros/ros.h>
+#include <ros/master.h>
 #include <signal.h>
 #include <dynamic_reconfigure/server.h>
 #include <sensor_msgs/PointCloud2.h>
@@ -25,16 +26,6 @@ sensor_msgs::PointCloud2 cloud2msg(pcl::PointCloud<T> cloud, const ros::Time& st
     cloud_ROS.header.stamp = stamp;
     cloud_ROS.header.frame_id = frame_id;
     return cloud_ROS;
-}
-
-// Callback function for parameter changes
-void reconfigureCallback(const patchworkpp::PatchworkppConfig& config, uint32_t level)
-{
-  // Update your parameters based on the changes
-  // You can access the parameters using config.param_name
-  // For example: int parameter = config.int_param;
-  // Your code to handle parameter changes goes here
-  ROS_INFO("Updated parameters");
 }
 
 void callbackCloud(const sensor_msgs::PointCloud2::Ptr &cloud_msg)
@@ -63,9 +54,6 @@ int main(int argc, char**argv) {
     ros::NodeHandle nh;
     ros::NodeHandle pnh("~");
 
-    std::string cloud_topic;
-    pnh.param<string>("cloud_topic", cloud_topic, "/pointcloud");
-
     ROS_INFO("Operating patchwork++...");
     PatchworkppGroundSeg.reset(new PatchWorkpp<PointType>());
 
@@ -73,17 +61,30 @@ int main(int argc, char**argv) {
     pub_ground      = pnh.advertise<sensor_msgs::PointCloud2>("ground", 100, true);
     pub_non_ground  = pnh.advertise<sensor_msgs::PointCloud2>("nonground", 100, true);
 
-    ros::Subscriber sub_cloud = nh.subscribe(cloud_topic, 100, callbackCloud);
+    ros::Subscriber sub_cloud = nh.subscribe(PatchworkppGroundSeg->topic(), 100, callbackCloud);
 
-    // Create a dynamic reconfigure server
-    dynamic_reconfigure::Server<patchworkpp::PatchworkppConfig> server;
-    dynamic_reconfigure::Server<patchworkpp::PatchworkppConfig>::CallbackType f;
+    while (ros::ok())
+    {
+        auto [topic_changed, topic] = PatchworkppGroundSeg->topic_changed();
+        if (topic_changed) {
+            std::vector<ros::master::TopicInfo> topics;
+            if (ros::master::check()) {
+                ros::master::getTopics(topics);
 
-    // Set the callback function
-    f = boost::bind(&reconfigureCallback, _1, _2);
-    server.setCallback(f);
+                bool topic_exists = std::find_if(topics.begin(), topics.end(), [&topic](const auto& topic_info) { return topic_info.name == topic; }) != topics.end();
 
-    ros::spin();
+                if (topic_exists)
+                {
+                    sub_cloud = nh.subscribe(PatchworkppGroundSeg->topic(), 100, callbackCloud);
+                }
+                else
+                {
+                    ROS_WARN_STREAM("Topic " << topic << " doesn't exist");
+                }
+            }
+        }
+        ros::spinOnce();
+    }
 
     return 0;
 }

--- a/src/demo_reconf.cpp
+++ b/src/demo_reconf.cpp
@@ -47,14 +47,14 @@ void callbackCloud(const sensor_msgs::PointCloud2::Ptr &cloud_msg)
 
     pcl::fromROSMsg(*cloud_msg, pc_curr);
 
-    PatchworkppGroundSeg->estimate_ground(pc_curr, pc_ground, pc_non_ground, time_taken);
+    if (PatchworkppGroundSeg->estimate_ground(pc_curr, pc_ground, pc_non_ground, time_taken)) {
+        ROS_INFO_STREAM("\033[1;32m" << "Input PointCloud: " << pc_curr.size() << " -> Ground: " << pc_ground.size() <<  "/ NonGround: " << pc_non_ground.size()
+            << " (running_time: " << time_taken << " sec)" << "\033[0m");
 
-    ROS_INFO_STREAM("\033[1;32m" << "Input PointCloud: " << pc_curr.size() << " -> Ground: " << pc_ground.size() <<  "/ NonGround: " << pc_non_ground.size()
-         << " (running_time: " << time_taken << " sec)" << "\033[0m");
-
-    pub_cloud.publish(cloud2msg(pc_curr, cloud_msg->header.stamp, cloud_msg->header.frame_id));
-    pub_ground.publish(cloud2msg(pc_ground, cloud_msg->header.stamp, cloud_msg->header.frame_id));
-    pub_non_ground.publish(cloud2msg(pc_non_ground, cloud_msg->header.stamp, cloud_msg->header.frame_id));
+        pub_cloud.publish(cloud2msg(pc_curr, cloud_msg->header.stamp, cloud_msg->header.frame_id));
+        pub_ground.publish(cloud2msg(pc_ground, cloud_msg->header.stamp, cloud_msg->header.frame_id));
+        pub_non_ground.publish(cloud2msg(pc_non_ground, cloud_msg->header.stamp, cloud_msg->header.frame_id));
+    }
 }
 
 int main(int argc, char**argv) {

--- a/src/demo_reconf.cpp
+++ b/src/demo_reconf.cpp
@@ -11,7 +11,6 @@
 #include "patchworkpp/patchworkpp.hpp"
 
 using PointType = pcl::PointXYZI;
-using namespace std;
 
 std::unique_ptr<PatchWorkpp<PointType>> PatchworkppGroundSeg;
 
@@ -67,8 +66,8 @@ int main(int argc, char**argv) {
     std::string cloud_topic;
     pnh.param<string>("cloud_topic", cloud_topic, "/pointcloud");
 
-    cout << "Operating patchwork++..." << endl;
-    PatchworkppGroundSeg.reset(new PatchWorkpp<PointType>(pnh));
+    ROS_INFO("Operating patchwork++...");
+    PatchworkppGroundSeg.reset(new PatchWorkpp<PointType>());
 
     pub_cloud       = pnh.advertise<sensor_msgs::PointCloud2>("cloud", 100, true);
     pub_ground      = pnh.advertise<sensor_msgs::PointCloud2>("ground", 100, true);

--- a/src/demo_reconfigure.cpp
+++ b/src/demo_reconfigure.cpp
@@ -2,12 +2,12 @@
 // For disable PCL complile lib, to use PointXYZIR
 #define PCL_NO_PRECOMPILE
 
-#include <memory>
 #include <ros/ros.h>
 #include <signal.h>
+#include <dynamic_reconfigure/server.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <pcl_conversions/pcl_conversions.h>
-
+#include <patchworkpp/PatchworkppConfig.h>
 #include "patchworkpp/patchworkpp.hpp"
 
 using PointType = pcl::PointXYZI;
@@ -26,6 +26,16 @@ sensor_msgs::PointCloud2 cloud2msg(pcl::PointCloud<T> cloud, const ros::Time& st
     cloud_ROS.header.stamp = stamp;
     cloud_ROS.header.frame_id = frame_id;
     return cloud_ROS;
+}
+
+// Callback function for parameter changes
+void reconfigureCallback(const patchworkpp::PatchworkppConfig& config, uint32_t level)
+{
+  // Update your parameters based on the changes
+  // You can access the parameters using config.param_name
+  // For example: int parameter = config.int_param;
+  // Your code to handle parameter changes goes here
+  ROS_INFO("Updated parameters");
 }
 
 void callbackCloud(const sensor_msgs::PointCloud2::Ptr &cloud_msg)
@@ -66,11 +76,15 @@ int main(int argc, char**argv) {
 
     ros::Subscriber sub_cloud = nh.subscribe(cloud_topic, 100, callbackCloud);
 
+    // Create a dynamic reconfigure server
+    dynamic_reconfigure::Server<patchworkpp::PatchworkppConfig> server;
+    dynamic_reconfigure::Server<patchworkpp::PatchworkppConfig>::CallbackType f;
 
-    while (ros::ok())
-    {
-        ros::spinOnce();
-    }
+    // Set the callback function
+    f = boost::bind(&reconfigureCallback, _1, _2);
+    server.setCallback(f);
+
+    ros::spin();
 
     return 0;
 }

--- a/src/offline_kitti.cpp
+++ b/src/offline_kitti.cpp
@@ -15,7 +15,7 @@ using PointType = PointXYZILID;
 using namespace std;
 
 void signal_callback_handler(int signum) {
-    cout << "Caught Ctrl + c " << endl;
+    ROS_INFO("Caught Ctrl + c ");
     // Terminate program
     exit(signum);
 }
@@ -87,14 +87,14 @@ int main(int argc, char**argv) {
     int      N = loader.size();
     for (int n = init_idx; n < N; ++n) {     
 
-        cout << n << "th node come" << endl;
+        ROS_INFO("th node come");
         pcl::PointCloud<PointType> pc_curr;
         loader.get_cloud(n, pc_curr);
         pcl::PointCloud<PointType> pc_ground;
         pcl::PointCloud<PointType> pc_non_ground;
 
         static double time_taken;
-        cout << "Operating patchwork++..." << endl;
+        ROS_INFO("Operating patchwork++...");
 
         PatchworkppGroundSeg->estimate_ground(pc_curr, pc_ground, pc_non_ground, time_taken);
 

--- a/src/offline_kitti.cpp
+++ b/src/offline_kitti.cpp
@@ -43,7 +43,7 @@ int main(int argc, char**argv) {
     ros::Publisher FPPublisher;
     ros::Publisher FNPublisher;
 
-    boost::shared_ptr<PatchWorkpp<PointType> > PatchworkppGroundSeg;
+    std::unique_ptr<PatchWorkpp<PointType> > PatchworkppGroundSeg;
     std::string output_csvpath;
 
     std::string acc_filename;
@@ -80,7 +80,7 @@ int main(int argc, char**argv) {
 
     signal(SIGINT, signal_callback_handler);
 
-    PatchworkppGroundSeg.reset(new PatchWorkpp<PointXYZILID>(&nh));
+    PatchworkppGroundSeg.reset(new PatchWorkpp<PointXYZILID>(nh));
     data_path = data_path + "/" + seq;
     KittiLoader loader(data_path);
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -16,7 +16,7 @@ using PointType = PointXYZILID;
 using namespace std;
 
 void signal_callback_handler(int signum) {
-    cout << "Caught Ctrl + c " << endl;
+    ROS_INFO("Caught Ctrl + c ");
     // Terminate program
     exit(signum);
 }
@@ -96,14 +96,14 @@ int main(int argc, char**argv) {
     int      N = loader.size();
     for (int n = init_idx; n < N; ++n) {     
 
-        cout << n << "th node come" << endl;
+        ROS_INFO("th node come");
         pcl::PointCloud<PointType> pc_curr;
         loader.get_cloud(n, pc_curr);
         pcl::PointCloud<PointType> pc_ground;
         pcl::PointCloud<PointType> pc_non_ground;
 
         static double time_taken;
-        cout << "Operating patchwork++..." << endl;
+        ROS_INFO("Operating patchwork++...");
 
         PatchworkppGroundSeg->estimate_ground(pc_curr, pc_ground, pc_non_ground, time_taken);
 

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -2,6 +2,7 @@
 // For disable PCL complile lib, to use PointXYZIR
 #define PCL_NO_PRECOMPILE
 
+#include <memory>
 #include <ros/ros.h>
 #include <signal.h>
 #include <sensor_msgs/PointCloud2.h>
@@ -45,7 +46,7 @@ int main(int argc, char**argv) {
     // ros::Publisher FPPublisher;
     // ros::Publisher FNPublisher;
 
-    boost::shared_ptr<PatchWorkpp<PointType> > PatchworkppGroundSeg;
+    std::unique_ptr<PatchWorkpp<PointType>> PatchworkppGroundSeg;
     std::string output_csvpath;
 
     std::string acc_filename;
@@ -88,7 +89,7 @@ int main(int argc, char**argv) {
 
     signal(SIGINT, signal_callback_handler);
 
-    PatchworkppGroundSeg.reset(new PatchWorkpp<PointXYZILID>(&nh));
+    PatchworkppGroundSeg.reset(new PatchWorkpp<PointXYZILID>(nh));
     data_path = data_path + "/" + seq;
     KittiLoader loader(data_path);
 


### PR DESCRIPTION
This PR adds full support for the dynamic configuration of runtime parameters with `rqt_reconfigure` *while maintaining compatibility with setting params in `params.yaml`*.

The changed are quite large, so don't hesitate to ask me questions about changes.

If you consider merging, two things to note:
* I am pretty sure parameter "mode" is unused. I think it can be removed
* Please help me by setting sane min/max values in `Patchworkpp.cfg` and add additional configuration checks for validity in [patchworkpp/params.h](./include/patchworkpp/params.h)
* I did take the liberty to remove unused variables and fix some sign issues (int/size_t)

Let me know if you are interested in this PR.