### PR TITLE
register rclcpp component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,10 @@ target_link_libraries(demo ${LIBS} ${PCL_LIBRARIES} )
 add_library(patchworkpp SHARED src/patchworkpp.cpp)
 target_compile_definitions(patchworkpp PUBLIC "PATCHWORKPP_COMPOSITION_BUILDING_DLL")
 target_link_libraries(patchworkpp ${LIBS})
+rclcpp_components_register_node(patchworkpp
+  PLUGIN "patchworkpp::PatchworkppPointXYZI"
+  EXECUTABLE patchworkpp_point_xyzi
+)
 
 install(TARGETS
 patchworkpp


### PR DESCRIPTION
This registers the component with the ament index so it can be used with `launch_ros` as a `ComposableNode`.