### PR TITLE
docs(readme): point ROS 2 users to the main patchwork-plusplus repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@ This is the **ROS 1** package of Patchwork++ (@ IROS'22), a fast and robust grou
 
 <p align="center"><img src=pictures/patchwork++.gif alt="animated" /></p>
 
-> **Heads up — using ROS 2?** The main [`url-kaist/patchwork-plusplus`][patchwork++link] repository now natively supports ROS 2 (Humble and Jazzy are exercised in CI). If you are on ROS 2, please use that repository directly — there is a dedicated `ros2_node` target that you can launch out of the box, and the C++ / Python APIs in the same repo work alongside it. This `patchwork-plusplus-ros` repository remains for **ROS 1 (Noetic and earlier) users only**.
+> [!IMPORTANT]
+> **Using ROS 2?** The main [`url-kaist/patchwork-plusplus`][patchwork++link]
+> repository now natively supports ROS 2 (Humble and Jazzy are exercised in
+> CI). If you are on ROS 2, please use that repository directly — there is a
+> dedicated `ros2_node` target that you can launch out of the box, and the
+> C++ / Python APIs in the same repo work alongside it. This
+> `patchwork-plusplus-ros` repository remains for **ROS 1 (Noetic and
+> earlier) users only**.
 
 > If you are not familiar with ROS, please visit the [original repository][patchwork++link].
 


### PR DESCRIPTION
## What

Adds a GitHub `[!IMPORTANT]` callout near the top of the README so ROS 2 users do not start here by mistake. The main [`url-kaist/patchwork-plusplus`](https://github.com/url-kaist/patchwork-plusplus) repository now natively supports ROS 2 (Humble and Jazzy in CI, with a dedicated `ros2_node` target). This `patchwork-plusplus-ros` repository remains the ROS 1 wrapper.

## Why

Several users land on this repo from search and assume it is the ROS 2 home, then end up forking it to port to ROS 2 instead of using the upstream's native support.

## Preview

> [!IMPORTANT]
> **Using ROS 2?** The main [`url-kaist/patchwork-plusplus`](https://github.com/url-kaist/patchwork-plusplus)
> repository now natively supports ROS 2 (Humble and Jazzy are exercised in
> CI). If you are on ROS 2, please use that repository directly — there is a
> dedicated `ros2_node` target that you can launch out of the box, and the
> C++ / Python APIs in the same repo work alongside it. This
> `patchwork-plusplus-ros` repository remains for **ROS 1 (Noetic and
> earlier) users only**.

## Test plan

- [x] `git diff` confirms the change is README-only.
- [x] No algorithmic changes — the ROS 1 wrapper's `include/patchworkpp/patchworkpp.hpp` is verified to be the real Patchwork++ (uses uncentred plane distance, global `concentric_idx`, and adaptive A-GLE elevation thresholds), so no equivalents of url-kaist/patchwork-plusplus#89 are needed here.